### PR TITLE
fix: resolve lodash-es prototype pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5740,9 +5740,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
+  },
+  "overrides": {
+    "lodash-es": "4.17.23"
   }
 }


### PR DESCRIPTION
Resolved Dependabot alert for `lodash-es` Prototype Pollution Vulnerability.

Changes:
- Added `"overrides": { "lodash-es": "4.17.23" }` to `package.json` to force the use of the patched version.
- Ran `npm install` to update `package-lock.json`.
- Verified that `lodash-es` version is now `4.17.23` and that the application builds successfully.

Note: `npm run lint` fails due to a pre-existing configuration issue with ESLint v9 and Next.js, which is unrelated to this change.

---
*PR created automatically by Jules for task [8858455942811120981](https://jules.google.com/task/8858455942811120981) started by @aegisfleet*